### PR TITLE
Fix subtabs white textcolor on white background

### DIFF
--- a/lib/Screens/LivetimingArchive/races_list.dart
+++ b/lib/Screens/LivetimingArchive/races_list.dart
@@ -21,7 +21,6 @@ import 'package:boxbox/Screens/LivetimingArchive/live_timing.dart';
 import 'package:boxbox/Screens/schedule.dart';
 import 'package:boxbox/api/ergast.dart';
 import 'package:boxbox/api/race_components.dart';
-import 'package:boxbox/helpers/convert_ergast_and_formula_one.dart';
 import 'package:boxbox/helpers/loading_indicator_util.dart';
 import 'package:boxbox/helpers/request_error.dart';
 import 'package:flutter/material.dart';

--- a/lib/Screens/race_details.dart
+++ b/lib/Screens/race_details.dart
@@ -155,6 +155,9 @@ class _RaceDetailsScreenState extends State<RaceDetailsScreen> {
                                           .toUpperCase(),
                                     ),
                                   ],
+                                  labelColor: useDarkMode
+                                      ? Colors.white
+                                      : Theme.of(context).scaffoldBackgroundColor,
                                 ),
                                 Expanded(
                                   child: TabBarView(
@@ -198,6 +201,9 @@ class _RaceDetailsScreenState extends State<RaceDetailsScreen> {
                                           .toUpperCase(),
                                     ),
                                   ],
+                                  labelColor: useDarkMode
+                                      ? Colors.white
+                                      : Theme.of(context).scaffoldBackgroundColor,
                                 ),
                                 Expanded(
                                   child: TabBarView(


### PR DESCRIPTION
I noticed the sub tabs for Sprint (shootout & results) & Race (qualifyings & results) looked empty. A better way it to solve this globally instead of per tabview, but this works for now.

Keep up the good work, I'll try to contribute some more PRs if you appreciate it.