### PR TITLE
fix: avoid int pop payload in news filter bottom sheet

### DIFF
--- a/lib/providers/general/ui.dart
+++ b/lib/providers/general/ui.dart
@@ -153,7 +153,7 @@ class UIProvider {
                           height: 50,
                           child: FilledButton.tonal(
                             onPressed: () {
-                              Navigator.of(context).pop(0);
+                              Navigator.of(context).pop();
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(


### PR DESCRIPTION
Small fix: use Navigator.of(context).pop() instead of pop(0) to avoid returning an int when showCustomBottomSheet returns Future<String?>.

Fixes
Fixes #217 

**How to reproduce**

        1. Launch app.
        2. Tap the news filter icon.
        3. Select a topic and tap Apply.
        4. Previously the app threw: TypeError: 0: type 'int' is not a subtype of type 'String?'.

**What I changed**

        - [ui.dart]: changed Navigator.of(context).pop(0) → Navigator.of(context).pop().

**Testing**

        - Manual: followed reproduction steps and verified no TypeError and navigation to the filtered NewsFeed works.

**Notes for maintainers** 

        - Small, isolated change; no breaking behavior; ready to merge.